### PR TITLE
Call va_start correctly

### DIFF
--- a/src/tek/makefile.c
+++ b/src/tek/makefile.c
@@ -111,7 +111,7 @@ void makefile_add_dep(struct makefile *m, const char *format, ...)
 
     fprintf(m->file, " ");
 
-    va_start(args, NULL);
+    va_start(args, format);
     vfprintf(m->file, format, args);
     va_end(args);
 }
@@ -146,7 +146,7 @@ void makefile_nam_cmd(struct makefile *m, const char *format, ...)
 
     fprintf(m->file, "\t@");
 
-    va_start(args, NULL);
+    va_start(args, format);
     vfprintf(m->file, format, args);
     va_end(args);
 
@@ -170,7 +170,7 @@ void makefile_add_cmd(struct makefile *m, const char *format, ...)
     fprintf(m->file, "\t@");
 #endif
 
-    va_start(args, NULL);
+    va_start(args, format);
     vfprintf(m->file, format, args);
     va_end(args);
 


### PR DESCRIPTION
The va_start macro needs to take the last named function parameter,
not NULL. From `man 3 va_start`:

```
 The parameter last is the name of the last parameter before the variable
 argument list, i.e., the last parameter of which the calling function
 knows the type.
```

Fixes the other issues from #1
